### PR TITLE
template and Latin Modern

### DIFF
--- a/regular/1/a/ispalindrom/ispalindrom_td.tex
+++ b/regular/1/a/ispalindrom/ispalindrom_td.tex
@@ -1,18 +1,8 @@
-\documentclass{article}
-\usepackage[utf8]{inputenc}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\usepackage[T1]{fontenc}
-\pagestyle{empty}
-\parindent0pt
+\input{../../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
+\osuetitle{1}
 
 \section*{Aufgabenstellung A}
 
@@ -51,5 +41,7 @@ Testen Sie Ihr Programm mit verschiedenen Eingaben, wie z.B.:
       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       ispalindrom: Eingabe zu lang, max 40 Zeichen!
 \end{verbatim}
+
+\osueguidelinesone
 
 \end{document}

--- a/regular/1/a/mycompress/mycompress_td.tex
+++ b/regular/1/a/mycompress/mycompress_td.tex
@@ -1,17 +1,9 @@
-\documentclass{article}
-\usepackage[utf8]{inputenc}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\pagestyle{empty}
-\parindent0pt
+\input{../../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
- 
+
+\osuetitle{1}
+
 \section*{Aufgabenstellung A}
        Schreiben Sie ein C-Programm \emph{mycompress},
       das die als Argumente übergebenen Dateien mittels
@@ -72,8 +64,8 @@ und die Outputdatei:
 \end{verbatim}
 
 liefern.
-    	
-	
+
+\osueguidelinesone
 
 \end{document}
 

--- a/regular/1/a/mydiff/mydiff_td.tex
+++ b/regular/1/a/mydiff/mydiff_td.tex
@@ -1,15 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[utf8]{inputenc}
-\pagestyle{empty}
+\input{../../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
+\osuetitle{1}
 
 \section*{Aufgabenstellung A}
 Implementieren Sie eine Abwandlung des Unix-Kommandos \emph{diff}.
@@ -67,6 +60,7 @@ Erstellen Sie eine Testdatei \emph{difftest1.txt} mit folgendem Inhalt:
     mydiff: File bloedsinn.txt existiert nicht!
 \end{verbatim}
 
+\osueguidelinesone
 
 \end{document}
  

--- a/regular/1/a/myexpand/myexpand_td.tex
+++ b/regular/1/a/myexpand/myexpand_td.tex
@@ -1,17 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\pagestyle{empty}
-\parindent0pt
+\input{../../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
+\osuetitle{1}
 
 \section*{Aufgabenstellung A}
 Implementieren Sie eine vereinfachte Variante des Unix-Kommandos {\tt
@@ -65,5 +56,7 @@ Ausgabe:
 	1234567890
 	123   90
 \end{verbatim}
+
+\osueguidelinesone
 
 \end{document}

--- a/regular/1/a/mysort/mysort_td.tex
+++ b/regular/1/a/mysort/mysort_td.tex
@@ -1,16 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\pagestyle{empty}
-\parindent0pt
+\input{../../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
+
+\osuetitle{1}
 
 \section*{Aufgabenstellung A}
 Schreiben Sie eine abgewandelte Version des UNIX-Kommandos {\bf sort} als C-Programm. Es soll nur die Option \verb|-r| (absteigend sortieren) implementiert werden. Alle anderen Optionen können ignoriert werden. Wird keine Datei angegeben so sollen die Daten \"uber \emph{stdin} eingelesen werden.
@@ -56,11 +48,6 @@ Ausgabe:
 \subsection*{Hinweis}
 {\bf { ( echo a ; echo B )} $|$ sort} sortiert B vor a, weil die Großbuchstaben im Zeichensatz vor den Kleinbuchstaben kommen. {\bf { ( echo a ; echo B )} $|$ sort -f} würde diese Eigenschaft ignorieren sein. Die Option \verb|-f| braucht aber {\bf nicht} implementiert werden.
 
+\osueguidelinesone
 
 \end{document}
-
-
-
-
-
-

--- a/regular/1/a/postfixcalc/postfixcalc_td.tex
+++ b/regular/1/a/postfixcalc/postfixcalc_td.tex
@@ -1,17 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\pagestyle{empty}
-\parindent0pt
+\input{../../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
 
+\osuetitle{1}
 
 \section*{Aufgabenstellung A}
 Schreiben Sie einen Rechner, der die Postfix-Notation versteht. 
@@ -76,11 +67,6 @@ Ausgabe:
 Leerzeichen zwischen Operatoren und Zahlen sind erlaubt, aber nicht notwendig. \verb|1 2 -3 + | ist nicht gültig, da das Minus zur \verb|3| gehört und von \emph{strtod(3)} konsumiert wird. \verb|1 2 *3 + | oder \verb|1 2 - 3 + | hingegen ist in Ordnung.
 Für die Winkelfunktionen müssen Sie \emph{math.h} einbinden, sowie beim Linken den Parameter \emph{-lm} verwenden.
 
+\osueguidelinesone
 
 \end{document}
-
-
-
-
-
-

--- a/regular/1/a/stegit/stegit_td.tex
+++ b/regular/1/a/stegit/stegit_td.tex
@@ -1,16 +1,9 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\pagestyle{empty}
-\parindent0pt
+\input{../../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
+
+\osuetitle{1}
+
 \section*{Aufgabenstellung A}
 
 Eines kalten Herbstabends finden Sie am Bildschirm eine seltsame Botschaft, die
@@ -96,4 +89,7 @@ stegit -f < secret_message_within
 \end{verbatim}
 die geheime Botschaft wiederherzustellen. Sie könnte Sie vor bösen
 Überraschungen bewahren.
+
+\osueguidelinesone
+
 \end{document}

--- a/regular/1/b/mastermind/mastermind_td.tex
+++ b/regular/1/b/mastermind/mastermind_td.tex
@@ -1,20 +1,10 @@
-\documentclass{article}
-\usepackage[utf8]{inputenc}
-\usepackage[german]{babel}
-\usepackage{bytefield}
-\usepackage{a4wide}
-\usepackage{nameref}
-\parindent0pt
-\pagestyle{empty}
+\input{../../../template.ltx}
 
+\usepackage{bytefield}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 1
-\end{Large}
-\end{center}
 
+\osuetitle{1}
 
 \section*{Aufgabenstellung B -- Mastermind}\label{sec:aufgabenstellung}
 Implementieren Sie einen Client und einen Server, die mittels TCP/IP
@@ -198,5 +188,8 @@ benötigt werden, um ein Spiel zu gewinnen (average rounds per game).
 Ben\"otigt Ihre L\"osung im Durchschnitt weniger als 20 Runden, und verliert kein
 einziges Spiel, so erhalten Sie 5 Bonuspunkte. Weitere 5 Bonuspunkte werden vergeben,
 wenn der Client das Spiel in durchschnittlich 8 oder weniger Runden gewinnt.
+
+\osueguidelinesone
+
 \end{document}
 

--- a/regular/2/calc/calc_td.tex
+++ b/regular/2/calc/calc_td.tex
@@ -2,26 +2,11 @@
 % Sysprog SS 2005
 % Beispiel 3: calculator
 % Martin Kirner
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\usepackage{url}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 2
-\end{Large}
-\end{center}
-
-
-
+\osuetitle{2}
 
 \section*{Aufgabenstellung}
 
@@ -75,8 +60,6 @@ Sie die Ergebnisse abrunden (Kommastellen abschneiden) – die Eingabe
 \verb_5 2 /_ ergibt als Ergebnis einfach \verb_2_ anstelle von
 \verb_2.5_.
 
+\osueguidelinestwo
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
 \end{document}

--- a/regular/2/dsort/dsort_td.tex
+++ b/regular/2/dsort/dsort_td.tex
@@ -1,24 +1,9 @@
 % dsort, 11/2010, Thomas Ogrisegg
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\usepackage{url}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
-
-
-
+\osuetitle{2}
 
 \section*{Aufgabenstellung}
 
@@ -105,7 +90,6 @@ erst sichtbar, wenn mit\\
 freigegeben werden (besonders im Fehlerfall)!
 \end{itemize}
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/encr/encr_td.tex
+++ b/regular/2/encr/encr_td.tex
@@ -2,26 +2,11 @@
 % Sysprog SS 2005
 % Beispiel 3: encr
 % Christian Steiner
-
-\documentclass{article}
-\usepackage{a4wide}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{url}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
-
-
-
+\osuetitle{2}
 
 \section*{Aufgabenstellung}
 
@@ -83,7 +68,6 @@ ein Signal terminiert wird, während noch Kindprozesse aktiv sind. Auch
 in diesem Fall muss der Vaterprozess auf das Terminieren seiner Kinder
 warten.
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/forksort/forksort_td.tex
+++ b/regular/2/forksort/forksort_td.tex
@@ -1,19 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{url}
-\usepackage{a4wide}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
+\osuetitle{2}
 
 \section{Forksort}
 
@@ -82,7 +71,6 @@ Zum Testen der Merge-Implementierung können Sie mit \emph{execlp(3)} statt
 Forksort auch \emph{sort(1)} aufrufen. Für die endgültige Abgabe ist diese
 Vorgehensweise nicht gültig, zum Testen aber durchaus sinnvoll.
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/hashsum/hashsum_td.tex
+++ b/regular/2/hashsum/hashsum_td.tex
@@ -2,25 +2,11 @@
 % Sysprog WS 2010
 % Beispiel 2: Hashsum
 % Sebastian Falbesoner
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
-\usepackage{a4wide}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
-
-
-
+\osuetitle{2}
 
 \section*{Aufgabenstellung}
 
@@ -56,10 +42,6 @@ gelisteten Einträgen um Dateien handelt (z.B.\ \texttt{.} und \texttt{..}); in 
 mittels \texttt{wait()/waitpid()} ermittelt werden kann) und der Eintrag soll in
 diesem Fall ignoriert werden.
 
-Bitte beachten Sie auch die Allgemeinen Hinweise zur
-Beispielgruppe 2 und die Richtlinien für die Erstellung von
-C-Programmen auf der Übungs-Website.
-
 \section*{Beispielaufruf}
 \begin{verbatim}
 [~]$ mkdir hashtests
@@ -74,4 +56,7 @@ emptyfile: d41d8cd98f00b204e9800998ecf8427e empty
 textfile: 536b30bbea5ee48aca04807038e25875 ASCII text
 [~]$
 \end{verbatim}
+
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/mygzip/mygzip_td.tex
+++ b/regular/2/mygzip/mygzip_td.tex
@@ -1,19 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{url}
-\usepackage{a4wide}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
+\osuetitle{2}
 
 \section{Benutzung von \emph{gzip}}
 
@@ -32,7 +21,6 @@ Der Vater liest die zu komprimierenden Daten von \emph{stdin} ein und schreibt s
 Das zweite Kind liest über die zweite Pipe vom \emph{gzip}-Prozess und schreibt die gelesenen Daten in die Datei \emph{file} bzw.\ auf \emph{stdout} wenn keine Datei angegeben wurde.
 Achten Sie darauf, das Sie die Dateien binär öffnen.
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/proxy/proxy_td.tex
+++ b/regular/2/proxy/proxy_td.tex
@@ -2,24 +2,11 @@
 % Sysprog SS 2005
 % Beispiel 3: proxy
 % Christian Steiner
-
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\usepackage{url}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
+\osuetitle{2}
 
 \section*{Aufgabenstellung}
 
@@ -66,7 +53,6 @@ Verwenden Sie \verb_proxy_, um mehrere Programme auszuführen:
 	./proxy -i - -o - -- grep -ni
 \end{verbatim}
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/randsched/randsched_td.tex
+++ b/regular/2/randsched/randsched_td.tex
@@ -1,19 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\usepackage{url}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
-\section*{Aufgabenstellung}
+
+\osuetitle{2}
 
 Sie sind der neue Systemadministrator im lokalen Atomkraftwerk. Schon bald ist
 Ihnen klar, dass im Wesentlichen einfach nur alle paar Minuten ein Programm
@@ -103,7 +92,6 @@ Die Meldung \verb_SHUTDOWN COMPLETED_ ist eigentlich von \emph{rshutdown} und
 scheint nicht im logfile auf, wo aber sehr wohl \verb_EMERGENCY SUCCESSFUL_
 anzeigt, dass der \emph{emergency}-Prozess erfolgreich war.
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/stillepost/stillepost_td.tex
+++ b/regular/2/stillepost/stillepost_td.tex
@@ -2,26 +2,11 @@
 % Sysprog WS 2005
 % Beispiel 3: stillepost
 % Dietmar Schabus (e0147322@student.tuwien.ac.at)
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\usepackage{url}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
-
-
-
+\osuetitle{2}
 
 \section*{Aufgabenstellung}
 
@@ -108,7 +93,6 @@ Die Ausgabe ihres Programms muss nicht genau wie in dem Beispiel
 formatiert sein. Natürlich wird der String umso unkenntlicher, je
 kürzer er ist.
 
-\section*{Richtlinien}
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 2 und die Richtlinien f\"ur die Erstellung von C-Programmen auf der \"Ubungswebsite.
-Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in Doxygen zu f\"uhren. Es muss zumindest das HTML Output generierbar sein. Bitte dokumentieren Sie ausnahmslos alle Funktionen (auch static-Funktionen, siehe \verb|EXTRACT_STATIC| im Doxygen Cfg-File). Eine kurze Einf\"uhrung haben wir Ihnen auf: \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer} bereitgestellt. Achten Sie weiters darauf, dass nach au{\ss}en hin sichtbare Funktionen (exportierte Funktionen) im Header File beschrieben werden und lokale (static Funktionen) nur im C File. Sie sollten auch Ihre Typen (insb. structs), Konstanten und globale Variablen dokumentieren. 
+\osueguidelinestwo
+
 \end{document}

--- a/regular/2/websh/websh_td.tex
+++ b/regular/2/websh/websh_td.tex
@@ -2,26 +2,11 @@
 % Sysprog WS 2010
 % Beispiel 2: websh
 % Philip Pickering
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\usepackage{url}
-\parindent0pt
-\addtolength{\parskip}{10pt}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS BEISPIEL 2
-\end{Large}
-\end{center}
-
-
-
+\osuetitle{2}
 
 \section*{Aufgabenstellung}
 
@@ -75,10 +60,6 @@ sollte folgende Ausgabe produzieren:
 </BODY></HTML> 
 \end{verbatim}
 
-Bitte beachten Sie auch die Allgemeinen Hinweise zur
-Beispielgruppe 2 und die Richtlinien für die Erstellung von
-C-Programmen auf der Übungs-Website.
-
-
+\osueguidelinestwo
 
 \end{document}

--- a/regular/3/4wins/4wins_td.tex
+++ b/regular/3/4wins/4wins_td.tex
@@ -1,14 +1,9 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\parindent0pt
+\input{../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 3
-\end{Large}
-\end{center}
+
+\osuetitle{3}
+
 \section*{Aufgabenstellung}
 \textbf{4 Gewinnt}
 
@@ -36,8 +31,6 @@ q              Beenden
 
 Beim Beenden des \emph{Client}s soll das Spiel erhalten bleiben, sodass es beim erneuten Start des \emph{Client}s weitergespielt werden kann.
 
-
-
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 3 und die Richtlinien f"ur die Erstellung von C-Programmen.
+\osueguidelinesthree
 
 \end{document}

--- a/regular/3/caesar/caesar_td.tex
+++ b/regular/3/caesar/caesar_td.tex
@@ -2,21 +2,11 @@
 % Sysprog WS 2005
 % Beispiel 2: caesar
 % Dietmar Schabus (e0147322@student.tuwien.ac.at)
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\parindent0pt
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 3
-\end{Large}
-\end{center}
-
-
+\osuetitle{3}
 
 \section*{Aufgabenstellung}
 
@@ -87,7 +77,6 @@ Implementierung):
 \end{verbatim}
 Dann haben Sie in \emph{t2} die verschl"usselte Version von \emph{t1}.
 
-\pagebreak
 Mit
 \begin{verbatim}
   readin t2 &
@@ -101,7 +90,6 @@ DASGARNICHTSCHWERWAR
 SCHONFASTFERTIG
 \end{verbatim}
 
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 3
-und die Richtlinien f"ur die Erstellung von C-Programmen.
+\osueguidelinesthree
 
 \end{document}

--- a/regular/3/calendar/calendar_td.tex
+++ b/regular/3/calendar/calendar_td.tex
@@ -1,26 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\parindent0pt
-
-\usepackage[utf8x]{inputenc}
-%\usepackage[latin1]{inputenc}
-\usepackage[T1]{fontenc}
-%\chapterstyle{veelo}
-%\usepackage{ucs}
-\usepackage{amsmath}
-\usepackage{amsfonts}
-\usepackage{amssymb}
-\usepackage{amsthm}
-
-\setlength\parindent{0pt}
-\setlength{\parskip}{1.5ex}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\LARGE OPERATING SYSTEMS UE BEISPIEL 3
-\end{center}
+\osuetitle{3}
 
 \section*{Aufgabenstellung}
 
@@ -73,10 +55,11 @@ Ersetzt den zweiten Eintrag am heutigen Tag durch \emph{Prf BSys}.
 Schlüssel eignen sich u.a. UNIX-Timestamps (siehe dazu \emph{time(7)} im Abschnitt \emph{The Epoch}
 bzw.\\ \emph{http://de.wikipedia.org/wiki/Unixzeit}), wobei sie dazu pro Tag einen geeigneten
 Repräsentanten finden sollten. Sinnvolle Funktionen um damit umzugehen sind \emph{time(2)} und,
-falls notwendig, \emph{mktime(3)}. \\
-Bitte beachten Sie auch die Allgemeinen Hinweise zu Beispielgruppe 3 und die Richtlinien
-für die Erstellung von C-Programmen.\\
+falls notwendig, \emph{mktime(3)}.
+
 Vergessen Sie keinesfalls auf sprechende Fehlermeldungen.
+
+\osueguidelinesthree
 
 \end{document}
 

--- a/regular/3/chstat/chstat_td.tex
+++ b/regular/3/chstat/chstat_td.tex
@@ -2,22 +2,11 @@
 % Sysprog WS 2005
 % Beispiel 2: chstat
 % Dietmar Schabus (e0147322@student.tuwien.ac.at)
-
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\parindent0pt
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 3
-\end{Large}
-\end{center}
-
-
-
+\osuetitle{3}
 
 \section*{Aufgabenstellung}
 
@@ -87,7 +76,6 @@ sichtbar sind, das Testen ohne {\tt -v} ist f"ur die Umleitung von
   readin < mytestfile
 \end{verbatim}
 
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 3
-und die Richtlinien f"ur die Erstellung von C-Programmen.
+\osueguidelinesthree
 
 \end{document}

--- a/regular/3/integrate/integrate_td.tex
+++ b/regular/3/integrate/integrate_td.tex
@@ -1,16 +1,11 @@
-\documentclass{article}
-\usepackage[utf8]{inputenc}
-\usepackage[german]{babel}
-\usepackage{a4wide}
+\input{../../template.ltx}
+
 \usepackage{graphicx}
-\parindent0pt
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 3
-\end{Large}
-\end{center}
+
+\osuetitle{3}
+
 \section*{Aufgabenstellung}
 
 \textbf{Shared-Integrator}
@@ -45,7 +40,7 @@ Die Kommunikation zwischen dem Server-Prozess und den Client-Prozessen soll übe
 
 \section*{Anleitung}
 Schreiben Sie zwei Programme, die die Prozesse mittels einer Client/Server-Struktur realisieren. Achten Sie auf eine saubere Terminierung.
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 3 und die Richtlinien
-für die Erstellung von C-Programmen.
+
+\osueguidelinesthree
 
 \end{document}

--- a/regular/3/lastmsg/lastmsg_td.tex
+++ b/regular/3/lastmsg/lastmsg_td.tex
@@ -1,19 +1,8 @@
-\documentclass{article}
-\usepackage[german]{babel}
-\usepackage[utf8]{inputenc}
-\usepackage{a4wide}
-\parindent0pt
-
+\input{../../template.ltx}
 
 \begin{document}
 
-
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 3
-\end{Large}
-\end{center}
-
+\osuetitle{3}
 
 \section*{Aufgabenstellung}
 
@@ -75,7 +64,7 @@ ab, so liegt vermutlich ein Synchronisierungsproblem vor.
 
 Die Optionen -c und -d schliessen sich wechselseitig aus.
 
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 3
-und die Richtlinien für die Erstellung von C-Programmen.
+\osueguidelinesthree
+
 \end{document}
 

--- a/regular/3/sortserver/sortserver_td.tex
+++ b/regular/3/sortserver/sortserver_td.tex
@@ -1,16 +1,8 @@
-\documentclass{article}
-\usepackage[utf8]{inputenc}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\usepackage{graphicx}
-\parindent0pt
+\input{../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 3
-\end{Large}
-\end{center}
+
+\osuetitle{3}
 
 \section*{Aufgabenstellung}
 
@@ -33,7 +25,7 @@ Es sollen beliebig lange Zahlenfolgen erlaubt sein, die Gr\"osse des Shared Memo
 
 \section*{Anleitung}
 Schreiben Sie zwei Programme, die die Prozesse mittels einer Client/Server-Struktur realisieren. Achten Sie auf eine saubere Terminierung, nachdem alle Zahlen ausgegeben sind. Verwenden Sie zum Sortieren den Befehl \emph{qsort(3)}.
-Bitte beachten Sie auch die Allgemeinen Hinweise zur Beispielgruppe 3 und die Richtlinien
-für die Erstellung von C-Programmen.
+
+\osueguidelinesthree
 
 \end{document}

--- a/regular/3/storetool/storetool_td.tex
+++ b/regular/3/storetool/storetool_td.tex
@@ -1,16 +1,8 @@
-\documentclass{article}
-\usepackage[utf8]{inputenc}
-\usepackage[german]{babel}
-\usepackage{a4wide}
-\usepackage{graphicx}
-\parindent0pt
+\input{../../template.ltx}
 
 \begin{document}
-\begin{center}
-\begin{Large}
-OPERATING SYSTEMS UE BEISPIEL 3
-\end{Large}
-\end{center}
+
+\osuetitle{3}
 
 \section*{Aufgabenstellung}
 
@@ -48,7 +40,8 @@ Nicht kritische Fehlermeldungen (jene die sich auf die Liste beziehen) sollen vo
 Bei dem Kommando \emph{quit} dürfen schon wartende Store-Tools mit einem Fehler terminieren. Nicht aber der Server und jenes Store-Tool das das Kommando sendet.
 
 \section*{Anleitung}
-Schreiben sie zwei Programme, die die Prozesse mittels einer Client/Server-Struktur realisieren. Achten sie auf eine saubere Terminierung. Bitte beachten sie auch die Allgemeinen Hinweise zur Beispielgruppe 3 und die Richtlinien
-für die Erstellung von C-Programmen.
+Schreiben sie zwei Programme, die die Prozesse mittels einer Client/Server-Struktur realisieren. Achten sie auf eine saubere Terminierung.
+
+\osueguidelinesthree
 
 \end{document}

--- a/regular/3/tictactoe/tictactoe_td.tex
+++ b/regular/3/tictactoe/tictactoe_td.tex
@@ -1,27 +1,8 @@
-\documentclass{article}
-\usepackage[ngerman]{babel}
-\usepackage{a4wide}
-\parindent0pt
-
-\usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
-
-%\chapterstyle{veelo}
-%\usepackage[english,ngerman]{babel}
-%\usepackage{ucs}
-\usepackage{amsmath}
-\usepackage{amsfonts}
-\usepackage{amssymb}
-\usepackage{amsthm}
-
-\setlength\parindent{0pt}
-\setlength{\parskip}{1.5ex}
+\input{../../template.ltx}
 
 \begin{document}
 
-\begin{center}
-\LARGE OPERATING SYSTEMS UE BEISPIEL 3
-\end{center}
+\osuetitle{3}
 
 \section*{Aufgabenstellung}
 
@@ -97,9 +78,9 @@ Tastendruck fortgesetzt werden. Der erste Zug pro Spiel soll immer vom Client au
 Um eine Kommunikation zwischen Server und Client abseits des Spielfelds zu ermöglichen
 (der Server muss den Client z.B. benachrichtigen falls er verloren oder gewonnen hat),
 ist es ratsam, außer dem Array noch eine Variable im Shared Memory zu definieren um sich
-mit Statusnachrichten auszutauschen. \\
-Bitte beachten Sie auch die Allgemeinen Hinweise zu Beispielgruppe 3 und die Richtlinien
-für die Erstellung von C-Programmen.
+mit Statusnachrichten auszutauschen.
+
+\osueguidelinesthree
 
 \end{document}
 

--- a/regular/template.ltx
+++ b/regular/template.ltx
@@ -1,0 +1,52 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[german]{babel}
+\usepackage{a4wide}
+\usepackage{url}
+\usepackage{lmodern}
+\usepackage{nameref}
+\pagestyle{empty}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{10pt}
+
+\newcommand\osuetitle[1]{
+\begin{center}
+\begin{Large}
+OPERATING SYSTEMS BEISPIEL #1
+\end{Large}
+\end{center}
+}
+
+\newcommand\osueguidelinesone{
+\section*{Richtlinien}
+
+Bitte beachten Sie auch die \textit{Richtlinien für die Erstellung von
+C-Programmen} auf der Übungswebsite.
+}
+
+\newcommand\osueguidelinestwo{
+\section*{Richtlinien}
+
+Bitte beachten Sie auch die \textit{Richtlinien für die Erstellung von
+C-Programmen} sowie die \textit{Allgemeinen Hinweise zur Beispielgruppe 2} auf
+der Übungswebsite.
+
+Insbesondere ist es ab dieser Beispielgruppe notwendig, die Dokumentation in
+Doxygen zu führen. Es muss zumindest das HTML-Output generierbar sein. Bitte
+dokumentieren Sie ausnahmslos alle Funktionen (auch \texttt{static}-Funktionen;
+siehe \texttt{EXTRACT\_STATIC} in der \texttt{Doxyfile}). Eine kurze Einführung
+haben wir Ihnen auf \url{http://wiki.vmars.tuwien.ac.at/index.php/Doxygen_Primer}
+bereitgestellt. Achten Sie weiters darauf, dass nach außen hin sichtbare
+Funktionen (exportierte Funktionen) in der Header-Datei und lokale
+(\texttt{static}) Funktionen nur in der C-Datei dokumentiert werden. Sie sollten
+auch Ihre Typen (insbesondere \texttt{struct}s), Konstanten und globale
+Variablen dokumentieren.
+}
+
+\newcommand\osueguidelinesthree{
+\section*{Richtlinien}
+
+Bitte beachten Sie auch die \textit{Richtlinien für die Erstellung von
+C-Programmen} sowie die \textit{Allgemeinen Hinweise zur Beispielgruppe 3} auf
+der Übungswebsite.
+}


### PR DESCRIPTION
- Introduce a template.

We've duplicated the stylistic definitions, the heading and the guideline hint far too often. Any sort of consistency became impossible. But no more. This stuff has been outsourced into a template file, now a one-stop shop for sweeping changes, should they ever be required.
- Use Latin Modern.

More or less the future of the Computer Modern fonts, Latin Modern is available in Type1 and OpenType formats. This will make font rendering far more beautiful (because Type3 font rendering is exceedingly poor in basically every PDF viewer) and should even improve copying and pasting from the documents.
